### PR TITLE
FIX: test on Repositories.spec.ts never passes

### DIFF
--- a/src/__tests__/Repositories.spec.ts
+++ b/src/__tests__/Repositories.spec.ts
@@ -105,10 +105,10 @@ describe('Repositories', () => {
           title: 'Rocket League',
         }),
         expect.objectContaining({
-          title: 'Need For Speed: Most Wanted',
+          title: 'The Last Of Us',
         }),
         expect.objectContaining({
-          title: 'The Last Of Us',
+          title: 'Need For Speed: Most Wanted',
         }),
       ],
     });


### PR DESCRIPTION
Test is always failing because of the order of the games on the array.